### PR TITLE
Add support for SAMD21J18A

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -13,7 +13,7 @@
 #elif (F_CPU >= 15400000UL) && (F_CPU <= 19000000L)
 #define COUNT 6
 // 168MHz STM32F405 STM32F407
-#elif defined(F_CPU == 168000000L)
+#elif (F_CPU == 168000000L)
 #define COUNT 40
 #else
 #error "CPU SPEED NOT SUPPORTED"

--- a/DHT.h
+++ b/DHT.h
@@ -12,6 +12,9 @@
 // 16 MHz(ish) AVR --------------------------------------------------------
 #elif (F_CPU >= 15400000UL) && (F_CPU <= 19000000L)
 #define COUNT 6
+// 48MHz SAMD21J18A (Sodaq Explorer)
+#elif (F_CPU == 48000000UL)
+#define COUNT 18
 // 168MHz STM32F405 STM32F407
 #elif (F_CPU == 168000000L)
 #define COUNT 40


### PR DESCRIPTION
Add support for SAMD21J18A (processor used on the Sodaq Explorer boards). Run at 48MHz, needs a COUNT of 18. Tested with DHT 22  (AM2302).