### PR TITLE
Add header file matching library name

### DIFF
--- a/Grove_Temperature_And_Humidity_Sensor.h
+++ b/Grove_Temperature_And_Humidity_Sensor.h
@@ -1,0 +1,2 @@
+#include "DHT.h"
+

--- a/examples/DHTtester/DHTtester.ino
+++ b/examples/DHTtester/DHTtester.ino
@@ -1,7 +1,7 @@
 // Example testing sketch for various DHT humidity/temperature sensors
 // Written by ladyada, public domain
 
-#include "DHT.h"
+#include "Grove_Temperature_And_Humidity_Sensor.h"
 
 // Uncomment whatever type you're using!
 //#define DHTTYPE DHT11   // DHT 11

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Grove Temperature And Humidity Sensor
-version=2.0.1
+version=2.0.2
 author=Seeed Studio
 maintainer=Seeed Studio <techsupport@seeed.cc>
 sentence=Arduino library to control Grove Temperature And Humidity Sensor, it contains chip DHT11 AM2302.


### PR DESCRIPTION
This PR adds a header file named `Grove_Temperature_And_Humidity_Sensor.h`, it is an empty file that includes `DHT.h` and can be used in `#include <Grove_Temperature_And_Humidity_Sensor.h>` statements (instead of `#include <DHT.h>`) to force the Arduino library resolution process to deterministically include this library instead of any other library providing the omnipresent `DHT.h` file.

This is the relevant WARNING after running [arduino-lint:](https://arduino.github.io/arduino-lint/1.2/)

```
Linting library in ./Workspace/Grove_Temperature_And_Humidity_Sensor
WARNING: No header file found matching library name (Grove_Temperature_And_Humidity_Sensor.h). Best practices are for
         primary header filename to match library name.
         See: https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format
         (Rule LS008)
```

I've updated the `library.properties` file to release version 2.0.2 of this library: you just need to git tag the master branch after merging the PR. I've placed this change in the second commit of this PR, in case you don't want it you can just cherry-pick the first one.

cc @alranel
